### PR TITLE
OT-740 Hidden columns are getting displayed In the lforms grid extens…

### DIFF
--- a/app/scripts/lforms-controllers.js
+++ b/app/scripts/lforms-controllers.js
@@ -466,7 +466,7 @@ angular.module('lformsWidget')
           this.uniqueGridHeaders=[];
           item.items.forEach(questionItems => {
             questionItems.items.forEach(subItems => {
-              if(!this.uniqueGridHeaders.includes(subItems.question)  && subItems.skipLogic?.conditions[0]?.trigger?.value != 'alwaysHide'){
+              if(!this.uniqueGridHeaders.includes(subItems.question)  && subItems.skipLogic?.conditions[0]?.trigger?.value != 'alwaysHide' && !subItems._isHiddenFromView){
                 this.uniqueGridHeaders.push(subItems.question);
               }   
           });


### PR DESCRIPTION
**Overview :**

- Hidden columns are getting displayed In the lforms grid extension. 

- when we add the hidden extension in the Lforms, The column and items in the column should get hide from the Display.

**How it was tested :** 

- Tested by running lforms on local 

**Screenshots :** 

![image](https://user-images.githubusercontent.com/92708869/218432995-599a5f58-0c5b-407d-8738-752f2471cd76.png)
