### PR TITLE
Removes extra header from the questionnaire v2 widget

### DIFF
--- a/app/scripts/lib/lforms-data.js
+++ b/app/scripts/lib/lforms-data.js
@@ -140,7 +140,7 @@
         {"question":"Comment", "questionCode":"comment","dataType":"TX","answers":""}
       ],
       // controls whether the column headers need to be displayed
-      showColumnHeaders: true,
+      showColumnHeaders: false,
       // controls the default answer layout for CWE/CNE typed items if answerLayout is not specified on the item's displayControl.
       // not changeable on a rendered form.
       defaultAnswerLayout: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/lforms",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "keywords": [
     "fhir",
     "Questionnaire",


### PR DESCRIPTION
**Overview**

- Remove extra header with Name Value Units above the group header.

**How it was tested**

- By verifying is extra header is getting removed from from or not 

**Screenshot**

![image](https://github.com/elimuinformatics/lforms/assets/92708869/4b790bba-afe0-403f-ab41-0289dc76ae91)
