### PR TITLE
LForms-Use-non-breaking-space-before-asterisk

### DIFF
--- a/src/app/lhc-item-question-text/lhc-item-question-text.component.html
+++ b/src/app/lhc-item-question-text/lhc-item-question-text.component.html
@@ -7,9 +7,8 @@
         <!-- prefix -->
         <span *ngIf="item.prefix" class="prefix" [style]="item._obj_prefixCSS">{{item.prefix}}</span>
         <!-- question text -->
-        <span class="question" [style]="item._obj_textCSS">{{item.question}}
-          <!-- required -->
-          <span *ngIf="item._answerRequired" class="lhc-required" title="Required">*</span>
+        <span class="question" [style]="item._obj_textCSS">
+          {{ item.question }}&nbsp;<span *ngIf="item._answerRequired" class="lhc-required" title="Required">*</span>
         </span>
       </label>
     </span>


### PR DESCRIPTION
## Overview

- Added &nbsp for removing nonbreaking space before the asterisk.
![image](https://github.com/elimuinformatics/lforms/assets/57406228/a408730f-05d0-41cd-a5e3-4959599b5fe9)


## How it was tested

- Tested using run @elimuinformatics/lforms app locally.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)