### PR TITLE
Grid column headings overflow on mobile screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/lforms",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "keywords": [
     "fhir",
     "Questionnaire",

--- a/src/matrix.css
+++ b/src/matrix.css
@@ -38,6 +38,16 @@
 .lhc-form .lhc-form-matrix-cell-other {
   text-align: center;
 }
+
+@media (max-width: 600px) {
+  .lhc-form .lhc-form-matrix-table th.lhc-form-matrix-cell,
+  .lhc-form .lhc-form-matrix-table th.lhc-form-grid-table-header {
+    white-space: normal;
+    word-break: keep-all;
+    overflow-wrap: break-word;
+  }
+}
+
 .lhc-form .lhc-form-matrix-table th {
   padding: 4px;
 }


### PR DESCRIPTION
- Updated matrix.css for responsive table headers.
- Bump version to `3.0.2`