### PR TITLE
Use granular npm token

### DIFF
--- a/Jenkinsfile-angular
+++ b/Jenkinsfile-angular
@@ -25,7 +25,7 @@ pipeline {
     }
     stage('Build') {
       environment {
-        NPM_TOKEN = credentials('NPM_TOKEN')
+        NPM_TOKEN = credentials('NPM_TOKEN_PUBLISH_LFORMS')
       }
       steps {
         echo "Started building"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elimuinformatics/lforms",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elimuinformatics/lforms",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^19.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/lforms",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "keywords": [
     "fhir",
     "Questionnaire",

--- a/src/version.json
+++ b/src/version.json
@@ -1,1 +1,1 @@
-{"lformsVersion":"4.0.1"}
+{"lformsVersion":"4.0.2"}


### PR DESCRIPTION
- Switch to granular NPM access token in Jenkins pipeline
- Increment version number to test npm publish